### PR TITLE
Fix git link in getting-started/vagrant

### DIFF
--- a/docs/getting-started/vagrant.md
+++ b/docs/getting-started/vagrant.md
@@ -43,7 +43,7 @@ Clone the Aurora repository
 
 To obtain the Aurora source distribution, clone its Git repository using the following command:
 
-     git clone git://git.apache.org/aurora.git
+     git clone https://github.com/aurora-scheduler/aurora
 
 
 Start the local cluster


### PR DESCRIPTION
### Description:

Change git clone link in the getting-started/vagrant.md file to refer actual aurora-scheduler's GitHub repository.

### Testing Done:
