### PR TITLE
Improve resume/pause update with regards to previously failed instances

### DIFF
--- a/src/main/java/org/apache/aurora/scheduler/updater/JobUpdateControllerImpl.java
+++ b/src/main/java/org/apache/aurora/scheduler/updater/JobUpdateControllerImpl.java
@@ -577,22 +577,22 @@ class JobUpdateControllerImpl implements JobUpdateController {
     if (action == STOP_WATCHING) {
       updates.remove(job);
     } else if (action == ROLL_FORWARD || action == ROLL_BACK) {
+      Set<Integer> prevFailedInstances = ImmutableSet.of();
       if (action == ROLL_BACK) {
         updates.remove(job);
       } else {
         checkState(!updates.containsKey(job), "Updater already exists for %s", job);
-      }
-
-      IJobUpdate jobUpdate = updateStore.fetchJobUpdate(key).get().getUpdate();
-      UpdateFactory.Update update;
-      try {
-        Set<Integer> prevFailedInstances = updateStore.fetchJobUpdate(key).get()
+        prevFailedInstances = updateStore.fetchJobUpdate(key).get()
             .getInstanceEvents()
             .stream()
             .filter(e -> e.getAction() == JobUpdateAction.INSTANCE_UPDATE_FAILED)
             .map(IJobInstanceUpdateEvent::getInstanceId)
             .collect(ImmutableSet.toImmutableSet());
+      }
 
+      IJobUpdate jobUpdate = updateStore.fetchJobUpdate(key).get().getUpdate();
+      UpdateFactory.Update update;
+      try {
         update = updateFactory.newUpdate(jobUpdate.getInstructions(),
             action == ROLL_FORWARD,
             prevFailedInstances);

--- a/src/main/java/org/apache/aurora/scheduler/updater/OneWayJobUpdater.java
+++ b/src/main/java/org/apache/aurora/scheduler/updater/OneWayJobUpdater.java
@@ -185,11 +185,10 @@ class OneWayJobUpdater<K, T> {
     } else {
       ImmutableMap.Builder<K, SideEffect> builder = ImmutableMap.builder();
       Set<K> working = filterByStatus(instances, WORKING);
-      Set<K> failed = filterByStatus(instances, FAILED);
       Set<K> nextGroup = strategy.getNextGroup(idle, working);
       if (!nextGroup.isEmpty()) {
         for (K instance : nextGroup) {
-          if (prevFailedInstances.contains(instance) && !failed.contains(instance)) {
+          if (prevFailedInstances.contains(instance)) {
             instances.get(instance).evaluateAsPrevFailed();
           } else {
             builder.put(instance, instances.get(instance).evaluate(stateProvider.getState(instance)));

--- a/src/main/java/org/apache/aurora/scheduler/updater/OneWayJobUpdater.java
+++ b/src/main/java/org/apache/aurora/scheduler/updater/OneWayJobUpdater.java
@@ -190,7 +190,7 @@ class OneWayJobUpdater<K, T> {
       if (!nextGroup.isEmpty()) {
         for (K instance : nextGroup) {
           if (prevFailedInstances.contains(instance) && !failed.contains(instance)) {
-            builder.put(instance, instances.get(instance).evaluateAsPrevFailed());
+            instances.get(instance).evaluateAsPrevFailed();
           } else {
             builder.put(instance, instances.get(instance).evaluate(stateProvider.getState(instance)));
           }

--- a/src/main/java/org/apache/aurora/scheduler/updater/OneWayJobUpdater.java
+++ b/src/main/java/org/apache/aurora/scheduler/updater/OneWayJobUpdater.java
@@ -250,11 +250,8 @@ class OneWayJobUpdater<K, T> {
     }
 
     void evaluateAsPrevFailed() {
-      ImmutableSet.Builder<SideEffect.InstanceUpdateStatus> statusChanges = ImmutableSet.builder();
       stateMachine.transition(WORKING);
-      statusChanges.add(WORKING);
       stateMachine.transition(FAILED);
-      statusChanges.add(FAILED);
     }
 
     SideEffect evaluate(T actualState) {

--- a/src/main/java/org/apache/aurora/scheduler/updater/OneWayJobUpdater.java
+++ b/src/main/java/org/apache/aurora/scheduler/updater/OneWayJobUpdater.java
@@ -185,10 +185,11 @@ class OneWayJobUpdater<K, T> {
     } else {
       ImmutableMap.Builder<K, SideEffect> builder = ImmutableMap.builder();
       Set<K> working = filterByStatus(instances, WORKING);
+      Set<K> failed = filterByStatus(instances, FAILED);
       Set<K> nextGroup = strategy.getNextGroup(idle, working);
       if (!nextGroup.isEmpty()) {
         for (K instance : nextGroup) {
-          if(prevFailedInstances.contains(instance)) {
+          if (prevFailedInstances.contains(instance) && !failed.contains(instance)) {
             builder.put(instance, instances.get(instance).evaluateAsPrevFailed());
           } else {
             builder.put(instance, instances.get(instance).evaluate(stateProvider.getState(instance)));

--- a/src/main/java/org/apache/aurora/scheduler/updater/OneWayJobUpdater.java
+++ b/src/main/java/org/apache/aurora/scheduler/updater/OneWayJobUpdater.java
@@ -252,7 +252,7 @@ class OneWayJobUpdater<K, T> {
       statusChanges.add(WORKING);
       stateMachine.transition(FAILED);
       statusChanges.add(FAILED);
-      return new SideEffect(Optional.empty(), statusChanges.build(), Optional.empty());
+      return new SideEffect(Result.FAILED_TERMINATED.getAction(), statusChanges.build(), Result.FAILED_TERMINATED.getFailure());
     }
 
     SideEffect evaluate(T actualState) {

--- a/src/main/java/org/apache/aurora/scheduler/updater/OneWayJobUpdater.java
+++ b/src/main/java/org/apache/aurora/scheduler/updater/OneWayJobUpdater.java
@@ -180,6 +180,7 @@ class OneWayJobUpdater<K, T> {
     } else {
       ImmutableMap.Builder<K, SideEffect> builder = ImmutableMap.builder();
       Set<K> working = filterByStatus(instances, WORKING);
+      Set<K> failed = filterByStatus(instances, FAILED);
       Set<K> nextGroup = strategy.getNextGroup(idle, working);
       if (!nextGroup.isEmpty()) {
         for (K instance : nextGroup) {
@@ -189,7 +190,7 @@ class OneWayJobUpdater<K, T> {
           // evaluates successfully updated instances to a NOOP but incorrectly attempts to
           // "re-update" previously failed instances.
           // Here we short circuit here to avoid retrying previously failed instances.
-          if (prevFailedInstances.contains(instance)) {
+          if (prevFailedInstances.contains(instance) && !failed.contains(instance)) {
             instances.get(instance).evaluateAsPrevFailed();
           } else {
             builder.put(

--- a/src/main/java/org/apache/aurora/scheduler/updater/OneWayJobUpdater.java
+++ b/src/main/java/org/apache/aurora/scheduler/updater/OneWayJobUpdater.java
@@ -15,7 +15,6 @@ package org.apache.aurora.scheduler.updater;
 
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -180,7 +179,6 @@ class OneWayJobUpdater<K, T> {
     } else {
       ImmutableMap.Builder<K, SideEffect> builder = ImmutableMap.builder();
       Set<K> working = filterByStatus(instances, WORKING);
-      Set<K> failed = filterByStatus(instances, FAILED);
       Set<K> nextGroup = strategy.getNextGroup(idle, working);
       if (!nextGroup.isEmpty()) {
         for (K instance : nextGroup) {

--- a/src/main/java/org/apache/aurora/scheduler/updater/OneWayJobUpdater.java
+++ b/src/main/java/org/apache/aurora/scheduler/updater/OneWayJobUpdater.java
@@ -190,7 +190,7 @@ class OneWayJobUpdater<K, T> {
           // evaluates successfully updated instances to a NOOP but incorrectly attempts to
           // "re-update" previously failed instances.
           // Here we short circuit here to avoid retrying previously failed instances.
-          if (prevFailedInstances.contains(instance) && !failed.contains(instance)) {
+          if (prevFailedInstances.contains(instance)) {
             instances.get(instance).evaluateAsPrevFailed();
           } else {
             builder.put(

--- a/src/main/java/org/apache/aurora/scheduler/updater/UpdateFactory.java
+++ b/src/main/java/org/apache/aurora/scheduler/updater/UpdateFactory.java
@@ -59,7 +59,7 @@ interface UpdateFactory {
    *
    * @param configuration Configuration to act on.
    * @param rollingForward {@code true} if this is a job update, {@code false} if it is a rollback.
-   * @param prevFailedInstances A set of instances that previously failed before update was paused.
+   * @param prevFailedInstances A set of instances that previously failed before update was resumed.
    * @return An updater that will execute the job update as specified in the
    *         {@code configuration}.
    */
@@ -87,10 +87,6 @@ interface UpdateFactory {
       checkArgument(
           settings.getMinWaitInInstanceRunningMs() >= 0,
           "Min wait in running must be non-negative.");
-
-      if (!rollingForward) {
-        prevFailedInstances = ImmutableSet.of();
-      }
 
       if (settings.getUpdateStrategy().isSetBatchStrategy()) {
         checkArgument(

--- a/src/main/java/org/apache/aurora/scheduler/updater/UpdateFactory.java
+++ b/src/main/java/org/apache/aurora/scheduler/updater/UpdateFactory.java
@@ -14,6 +14,7 @@
 package org.apache.aurora.scheduler.updater;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -58,12 +59,14 @@ interface UpdateFactory {
    *
    * @param configuration Configuration to act on.
    * @param rollingForward {@code true} if this is a job update, {@code false} if it is a rollback.
+   * @param prevFailedInstances A set of instances that previously failed before update was paused.
    * @return An updater that will execute the job update as specified in the
    *         {@code configuration}.
    */
   Update newUpdate(
       IJobUpdateInstructions configuration,
-      boolean rollingForward);
+      boolean rollingForward,
+      Set<Integer> prevFailedInstances);
 
   class UpdateFactoryImpl implements UpdateFactory {
     private final Clock clock;
@@ -74,7 +77,10 @@ interface UpdateFactory {
     }
 
     @Override
-    public Update newUpdate(IJobUpdateInstructions instructions, boolean rollingForward) {
+    public Update newUpdate(
+        IJobUpdateInstructions instructions,
+        boolean rollingForward,
+        Set<Integer> prevFailedInstances) {
       requireNonNull(instructions);
       IJobUpdateSettings settings = instructions.getSettings();
 
@@ -164,7 +170,8 @@ interface UpdateFactory {
           new OneWayJobUpdater<>(
               strategy,
               settings.getMaxFailedInstances(),
-              evaluators.build()),
+              evaluators.build(),
+              prevFailedInstances),
           successStatus,
           failureStatus);
     }

--- a/src/main/java/org/apache/aurora/scheduler/updater/UpdateFactory.java
+++ b/src/main/java/org/apache/aurora/scheduler/updater/UpdateFactory.java
@@ -88,6 +88,10 @@ interface UpdateFactory {
           settings.getMinWaitInInstanceRunningMs() >= 0,
           "Min wait in running must be non-negative.");
 
+      if (!rollingForward) {
+        prevFailedInstances = ImmutableSet.of();
+      }
+
       if (settings.getUpdateStrategy().isSetBatchStrategy()) {
         checkArgument(
             settings.getUpdateStrategy().getBatchStrategy().getGroupSize() > 0,

--- a/src/main/java/org/apache/aurora/scheduler/updater/UpdateFactory.java
+++ b/src/main/java/org/apache/aurora/scheduler/updater/UpdateFactory.java
@@ -14,7 +14,6 @@
 package org.apache.aurora.scheduler.updater;
 
 import java.io.Serializable;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 

--- a/src/test/java/org/apache/aurora/scheduler/updater/OneWayJobUpdaterTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/updater/OneWayJobUpdaterTest.java
@@ -262,6 +262,36 @@ public class OneWayJobUpdaterTest extends EasyMockTest {
   }
 
   @Test
+  public void testEvaluatePreviouslyFailedInstance() {
+    expect(strategy.getNextGroup(ImmutableSet.of(0, 1, 2, 3), EMPTY))
+        .andReturn(ImmutableSet.of(0));
+    expect(strategy.getNextGroup(ImmutableSet.of(1, 2, 3), EMPTY))
+        .andReturn(ImmutableSet.of(1));
+    expect(strategy.getNextGroup(ImmutableSet.of(2, 3), ImmutableSet.of(1)))
+        .andReturn(ImmutableSet.of());
+    String s0 = "0";
+    String s1 = "1";
+
+    // We don't evaluate instance 0 because we're passing it in as a previously failed
+    // instance.
+    expectFetchAndEvaluate(1, instance1, s1, EVALUATE_ON_STATE_CHANGE);
+
+    control.replay();
+
+    jobUpdater = new OneWayJobUpdater<>(strategy, 1, allInstances, ImmutableSet.of(0));
+
+    evaluate(
+        OneWayStatus.WORKING,
+        ImmutableMap.of(1, sideEffect(AWAIT_STATE_CHANGE, InstanceUpdateStatus.WORKING)));
+
+    // Instance 0 previously failed so it should result in a NOOP even without evaluation.
+    evaluate(0, s0, OneWayStatus.WORKING, ImmutableMap.of());
+
+    // Reset global OneWayJobUpdater object
+    jobUpdater = new OneWayJobUpdater<>(strategy, 0, allInstances, ImmutableSet.of(0));
+  }
+
+  @Test
   public void testResultsObjectOverrides() {
     control.replay();
 

--- a/src/test/java/org/apache/aurora/scheduler/updater/OneWayJobUpdaterTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/updater/OneWayJobUpdaterTest.java
@@ -153,7 +153,7 @@ public class OneWayJobUpdaterTest extends EasyMockTest {
 
     control.replay();
 
-    jobUpdater = new OneWayJobUpdater<>(strategy, 0, allInstances);
+    jobUpdater = new OneWayJobUpdater<>(strategy, 0, allInstances, ImmutableSet.of());
 
     evaluate(
         OneWayStatus.WORKING,
@@ -204,7 +204,7 @@ public class OneWayJobUpdaterTest extends EasyMockTest {
 
     control.replay();
 
-    jobUpdater = new OneWayJobUpdater<>(strategy, 0, allInstances);
+    jobUpdater = new OneWayJobUpdater<>(strategy, 0, allInstances, ImmutableSet.of());
 
     evaluate(
         OneWayStatus.FAILED,
@@ -244,7 +244,7 @@ public class OneWayJobUpdaterTest extends EasyMockTest {
 
     control.replay();
 
-    jobUpdater = new OneWayJobUpdater<>(strategy, 0, allInstances);
+    jobUpdater = new OneWayJobUpdater<>(strategy, 0, allInstances, ImmutableSet.of());
 
     evaluate(
         OneWayStatus.WORKING,

--- a/src/test/java/org/apache/aurora/scheduler/updater/UpdateFactoryImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/updater/UpdateFactoryImplTest.java
@@ -61,13 +61,13 @@ public class UpdateFactoryImplTest {
 
   @Test
   public void testRollingForward() throws Exception  {
-    Update update = factory.newUpdate(INSTRUCTIONS, true);
+    Update update = factory.newUpdate(INSTRUCTIONS, true, ImmutableSet.of());
     assertEquals(ImmutableSet.of(0, 1, 2), update.getUpdater().getInstances());
   }
 
   @Test
   public void testRollingBack() throws Exception {
-    Update update = factory.newUpdate(INSTRUCTIONS, false);
+    Update update = factory.newUpdate(INSTRUCTIONS, false, ImmutableSet.of());
     assertEquals(ImmutableSet.of(0, 1, 2), update.getUpdater().getInstances());
   }
 
@@ -78,7 +78,7 @@ public class UpdateFactoryImplTest {
     config.setDesiredState(instanceConfig(new Range(1, 1)));
     config.getSettings().setUpdateOnlyTheseInstances(ImmutableSet.of(new Range(0, 1)));
 
-    Update update = factory.newUpdate(IJobUpdateInstructions.build(config), true);
+    Update update = factory.newUpdate(IJobUpdateInstructions.build(config), true, ImmutableSet.of());
     assertEquals(ImmutableSet.of(1), update.getUpdater().getInstances());
   }
 
@@ -89,7 +89,7 @@ public class UpdateFactoryImplTest {
     config.setDesiredState(instanceConfig(new Range(1, 1)));
     config.getSettings().setUpdateOnlyTheseInstances(ImmutableSet.of(new Range(0, 1)));
 
-    Update update = factory.newUpdate(IJobUpdateInstructions.build(config), false);
+    Update update = factory.newUpdate(IJobUpdateInstructions.build(config), false, ImmutableSet.of());
     assertEquals(ImmutableSet.of(1), update.getUpdater().getInstances());
   }
 
@@ -98,7 +98,7 @@ public class UpdateFactoryImplTest {
     JobUpdateInstructions config = INSTRUCTIONS.newBuilder();
     config.getDesiredState().setInstances(ImmutableSet.of(new Range(0, 1)));
 
-    Update update = factory.newUpdate(IJobUpdateInstructions.build(config), true);
+    Update update = factory.newUpdate(IJobUpdateInstructions.build(config), true, ImmutableSet.of());
     assertEquals(ImmutableSet.of(0, 1, 2), update.getUpdater().getInstances());
   }
 

--- a/src/test/java/org/apache/aurora/scheduler/updater/UpdateFactoryImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/updater/UpdateFactoryImplTest.java
@@ -78,7 +78,10 @@ public class UpdateFactoryImplTest {
     config.setDesiredState(instanceConfig(new Range(1, 1)));
     config.getSettings().setUpdateOnlyTheseInstances(ImmutableSet.of(new Range(0, 1)));
 
-    Update update = factory.newUpdate(IJobUpdateInstructions.build(config), true, ImmutableSet.of());
+    Update update = factory.newUpdate(
+        IJobUpdateInstructions.build(config),
+        true,
+        ImmutableSet.of());
     assertEquals(ImmutableSet.of(1), update.getUpdater().getInstances());
   }
 
@@ -89,7 +92,10 @@ public class UpdateFactoryImplTest {
     config.setDesiredState(instanceConfig(new Range(1, 1)));
     config.getSettings().setUpdateOnlyTheseInstances(ImmutableSet.of(new Range(0, 1)));
 
-    Update update = factory.newUpdate(IJobUpdateInstructions.build(config), false, ImmutableSet.of());
+    Update update = factory.newUpdate(
+        IJobUpdateInstructions.build(config),
+        false,
+        ImmutableSet.of());
     assertEquals(ImmutableSet.of(1), update.getUpdater().getInstances());
   }
 
@@ -98,7 +104,10 @@ public class UpdateFactoryImplTest {
     JobUpdateInstructions config = INSTRUCTIONS.newBuilder();
     config.getDesiredState().setInstances(ImmutableSet.of(new Range(0, 1)));
 
-    Update update = factory.newUpdate(IJobUpdateInstructions.build(config), true, ImmutableSet.of());
+    Update update = factory.newUpdate(
+        IJobUpdateInstructions.build(config),
+        true,
+        ImmutableSet.of());
     assertEquals(ImmutableSet.of(0, 1, 2), update.getUpdater().getInstances());
   }
 


### PR DESCRIPTION
### Description:
Whenever a task is paused, the OneWayJobUpdater object is discarded. This results in the loss of the information the object was holding. Among this information is the previously failed/succeeded instances for an update.

In the case of instances that have previously succeeded, the side effects of throwing away this information is minimal. Due to the way the updating mechanism works, we will detect that task A has already transitioned to task A' successfully and is in the RUNNING state. Therefore, a NOOP will be generated.

In the case of instances that have previously failed, however, the updating mechanism will detect that the task is not in the RUNNING state and will attempt to remedy this by recreating the instance with the new configuration A'.

In the worst of cases, if the failure happens early in the update for an auto pause enabled update, this will cause the updater to continuously wait `min(instance time to failure, watch_secs)` * `max_per_shard_failures` at every resume event until the instance comes up correctly or the update enters a terminal state.

This patch improves on that behavior by repopulating some of the lost information in the form of a set of instances that previously failed. Upon encountering one of these, the OneWayJobUpdater mechanism silently transitions the instance to it's previous state and continues the update in way that doesn't interrupt the flow of other mechanisms (batching).


### Testing Done:
Tested using an update where shard 0 failed consistently with auto pause enabled and with update groups [1,2,3]

Ran end to end tests to confirm there were no side effects due to this change.

Ran quality check and integration tests.