### PR TITLE
Adding docker-compose based devlopment option for the scheduler.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,86 @@
+version: "2"
+
+services:
+  zk:
+    image: aurorascheduler/zookeeper
+    restart: on-failure
+    ports:
+    - "2181:2181"
+    environment:
+      ZK_CONFIG: tickTime=2000,initLimit=10,syncLimit=5,maxClientCnxns=128,forceSync=no,clientPort=2181
+      ZK_ID: 1
+    networks:
+      aurora_cluster:
+        ipv4_address: 192.168.33.2
+
+  master:
+    image: aurorascheduler/mesos-master:1.7.2
+    restart: on-failure
+    ports:
+    - "5050:5050"
+    environment:
+      MESOS_ZK: zk://192.168.33.2:2181/mesos
+      MESOS_QUORUM: 1
+      MESOS_HOSTNAME: localhost
+      MESOS_CLUSTER: test-cluster
+      MESOS_REGISTRY: replicated_log
+      MESOS_WORK_DIR: /tmp/mesos
+    networks:
+      aurora_cluster:
+        ipv4_address: 192.168.33.3
+    depends_on:
+    - zk
+
+  agent:
+    image: aurorascheduler/mesos-agent:1.7.2
+    pid: host
+    restart: on-failure
+    ports:
+      - "5061:5061"
+    environment:
+      MESOS_MASTER: zk://192.168.33.2:2181/mesos
+      MESOS_CONTAINERIZERS: docker,mesos
+      MESOS_HOSTNAME: localhost
+      MESOS_PORT: 5061
+      MESOS_RESOURCES: ports(*):[11000-11999]
+      MESOS_SYSTEMD_ENABLE_SUPPORT: 'false'
+      MESOS_WORK_DIR: /tmp/mesos
+    networks:
+      aurora_cluster:
+        ipv4_address: 192.168.33.5
+
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - zk
+
+  aurora:
+    image: aurorascheduler/scheduler:dev
+    pid: host
+    ports:
+    - "8081:8081"
+    restart: on-failure
+    environment:
+      CLUSTER_NAME: devcluster
+      ZK_ENDPOINTS: "192.168.33.2:2181"
+      MESOS_MASTER: "zk://192.168.33.2:2181/mesos"
+      EXTRA_SCHEDULER_ARGS: >
+        -http_authentication_mechanism=NONE
+    volumes:
+      - ./:/home/vagrant/aurora
+    networks:
+      aurora_cluster:
+        ipv4_address: 192.168.33.7
+    depends_on:
+    - zk
+    - master
+    - agent
+
+networks:
+  aurora_cluster:
+    driver: bridge
+    ipam:
+      config:
+      - subnet: 192.168.33.0/16
+        gateway: 192.168.33.1

--- a/docs/development/scheduler.md
+++ b/docs/development/scheduler.md
@@ -86,6 +86,33 @@ Gradle can generate project files for your IDE. To generate an IntelliJ IDEA pro
 
 and import the generated `aurora.ipr` file.
 
+Setting up docker-compose based dev cluster
+-----------------
+In order to set up a docker-compose based dev cluster for the scheduler, you need to
+[install docker-compose](https://docs.docker.com/compose/install/) on your machine.
+
+Run gradle to generate the installDist
+
+    ./gradlew installDist
+
+From the root of the Git repo bring up the cluster using docker-compose
+
+    docker-compose up -d
+
+Aurora components should now be reachable at:
+
+* Scheduler: http://localhost:8081
+* Mesos Master: http://localhost:5050
+* Mesos Agent: http://localhost:5061
+
+To apply any new changes to the scheduler simply run
+
+    ./gradlew compileJava && docker-compose restart
+
+Note that certain limitations apply to developing the scheduler using a docker based
+cluster. Such use-cases will probably involve launching other containers. 
+In such cases, it is more advisable to our vagrant setup as it will run a full fledged VM.
+
 Adding or Upgrading a Dependency
 --------------------------------
 New dependencies can be added from Maven central by adding a `compile` dependency to `build.gradle`.


### PR DESCRIPTION
### Description:
Adding support for using a docker-compose based set up for developing most aspects of the scheduler.
This makes it very simple to bring up or tear down a cluster when needed during development.


### Testing Done:
docker-compose up -d on root of the git repo and then going to http://localhost:8081 to verify the scheduler was running.