### PR TITLE
Upgrading Quartz scheduler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -400,7 +400,7 @@ dependencies {
   compile "org.eclipse.jetty:jetty-server:${jettyDep}"
   compile "org.eclipse.jetty:jetty-servlet:${jettyDep}"
   compile "org.eclipse.jetty:jetty-servlets:${jettyDep}"
-  compile 'org.quartz-scheduler:quartz:2.2.2'
+  compile 'org.quartz-scheduler:quartz:2.3.1'
 
   testCompile 'com.sun.jersey:jersey-client:1.19'
   testCompile "junit:junit:${junitRev}"


### PR DESCRIPTION
### Description:

Bumping up the Quartz scheduler version to 2.3.1


### Testing Done:

Integration tests.