### PR TITLE
Add missing change to Mesos 1.8.1

### DIFF
--- a/3rdparty/python/BUILD
+++ b/3rdparty/python/BUILD
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-MESOS_REV = '1.7.2'
+MESOS_REV = '1.8.1'
 
 python_requirement_library(
   name = 'mesos.interface',


### PR DESCRIPTION
### Description:
Upgrading python egg to be used to Mesos 1.8.1



### Testing Done:
