### PR TITLE
Update Vagrant box reference

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant.require_version ">= 2.2.9"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.hostname = "aurora.local"
   # See build-support/packer/README.md for instructions on updating this box.
-  config.vm.box = "apache-aurora/dev-environment"
+  config.vm.box = "aurora-scheduler/dev-environment"
   config.vm.box_version = "0.0.20"
 
   config.vm.define "devcluster" do |dev|


### PR DESCRIPTION
### Description:

Updates the vagrant box reference in `Vagrantfile` to point to the new https://app.vagrantup.com/aurora-scheduler/boxes/dev-environment instead of the Apache versions. Previously, trying to initialize a vagrant box from scratch failed because the missing version in the apache-aurora/dev-environment boxes.


### Testing Done:

Removed every aurora related vagrant box in the system, then `vagrant destroy; vagrant up; vagrant ssh` worked correctly.
